### PR TITLE
fix the shimmer

### DIFF
--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -39,6 +39,8 @@ tail_includes:
 
 </article>
 
+<script src="{{ '/assets/js/img-loading.js' | relative_url }}"></script>
+
 <script src="{{ '/assets/js/audio.js' | relative_url }}" data-tooltip="{{ site.data.locales[lang].layout.audio_tip }}"></script>
 
 <style>

--- a/assets/js/img-loading.js
+++ b/assets/js/img-loading.js
@@ -1,0 +1,69 @@
+/**
+ * Setting up image lazy loading and LQIP switching
+ */
+
+const ATTR_DATA_SRC = 'data-src';
+const ATTR_DATA_LQIP = 'data-lqip';
+
+const cover = {
+  SHIMMER: 'shimmer',
+  BLUR: 'blur'
+};
+
+function removeCover(clzss) {
+  this.parentElement.classList.remove(clzss);
+}
+
+function handleImage() {
+  if (!this.complete) {
+    return;
+  }
+
+  if (this.hasAttribute(ATTR_DATA_LQIP)) {
+    removeCover.call(this, cover.BLUR);
+  } else {
+    removeCover.call(this, cover.SHIMMER);
+  }
+}
+
+/**
+ * Switches the LQIP with the real image URL.
+ */
+function switchLQIP() {
+  const src = this.getAttribute(ATTR_DATA_SRC);
+  this.setAttribute('src', encodeURI(src));
+  this.removeAttribute(ATTR_DATA_SRC);
+}
+
+function loadImg() {
+  const images = document.querySelectorAll('article img');
+
+  if (images.length === 0) {
+    return;
+  }
+
+  images.forEach((img) => {
+    img.addEventListener('load', handleImage);
+  });
+
+  // Images loaded from the browser cache do not trigger the 'load' event
+  document.querySelectorAll('article img[loading="lazy"]').forEach((img) => {
+    if (img.complete) {
+      removeCover.call(img, cover.SHIMMER);
+    }
+  });
+
+  // LQIPs set by the data URI or WebP will not trigger the 'load' event,
+  // so manually convert the URI to the URL of a high-resolution image.
+  const lqips = document.querySelectorAll(
+    `article img[${ATTR_DATA_LQIP}="true"]`
+  );
+
+  if (lqips.length) {
+    lqips.forEach((lqip) => {
+      switchLQIP.call(lqip);
+    });
+  }
+}
+
+loadImg();


### PR DESCRIPTION
Shimmer was not being cleared when the image was loaded. 
It's because the code to remove it on load was only called in certain layouts, not my custom lesson layout. I didn't see an easy way to load the existing module, so I just copied it.